### PR TITLE
Fix delete handler for sensor.

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -384,7 +384,7 @@ function run() {
     })
   })
   .delete(function(req, res) {
-    bl.delete_sensor(req.params.id, function(callback) {
+    bl.delete_sensor(req.params.sensor_id, function(callback) {
       if(callback.error) res.status(callback.status).json(callback.error);
       else res.json(callback.message);
     })


### PR DESCRIPTION
This fixes the "The requested resource could not be found" error when trying to
delete a sensor.